### PR TITLE
Create unlines function

### DIFF
--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -405,6 +405,21 @@ Return a list of the lines in the string.
 ----
 
 
+=== unlines
+
+Joins a list of strings with a newline separator.  This operation is
+the opposite of lines.
+
+[source, clojure]
+----
+(str/unlines ["foo" "nbar"])
+;; => "foo\nbar"
+
+(str/unlines nil)
+;; => nil
+----
+
+
 === slice
 
 Extracts a section of a string and returns a new string.

--- a/spec/cuerdas/core_spec.cljx
+++ b/spec/cuerdas/core_spec.cljx
@@ -267,4 +267,9 @@
   (s/it "lines"
     (s/should= nil (str/lines nil))
     (s/should= ["foo" "bar"] (str/lines "foo\nbar")))
+
+  (s/it "unlines"
+    (s/should= nil (str/unlines nil))
+    (s/should= "foo\nbar" (str/unlines ["foo" "bar"]))
+    (s/should= "" (str/unlines [])))
 )

--- a/src/clj/cuerdas/core.clj
+++ b/src/clj/cuerdas/core.clj
@@ -263,6 +263,13 @@
   [s]
   (split s #"\n|\r\n"))
 
+(defn unlines
+  "Returns a new string joining a list of strings with a newline char (\\n)."
+  [s]
+  (if (nil? s)
+    s
+    (str/join "\n" s)))
+
 (defn format
   "Simple string interpolation."
   [s & args]

--- a/src/cljs/cuerdas/core.cljs
+++ b/src/cljs/cuerdas/core.cljs
@@ -134,6 +134,13 @@
   [s]
   (split s #"\n|\r\n"))
 
+(defn unlines
+  "Returns a new string joining a list of strings with a newline char (\\n)."
+  [s]
+  (if (nil? s)
+    s
+    (str/join "\n" s)))
+
 (defn chars
   "Split a string in a seq of chars."
   [s]


### PR DESCRIPTION
Create the convenience function ```unlines```, which works as an opposite to ```lines```.  The name is taken from Haskell, which has both functions, ```lines``` and ```unlines```, even though it has other joining function such as intercalate.