### PR TITLE
starts-with?, ends-with? and  contains? return true for empty sub-string

### DIFF
--- a/src/cuerdas/core.cljc
+++ b/src/cuerdas/core.cljc
@@ -8,12 +8,17 @@
   #?(:clj (:import java.util.regex.Pattern
                    java.util.List)))
 
+(defn empty?
+  "Checks if a string is empty."
+  [^String s]
+  (= (count s) 0))
+
 (defn contains?
   "Determines whether a string contains a substring."
   [s subs]
   (when-not (nil? s)
     #?(:clj  (cond
-               (nil? subs) false
+               (empty? subs) true
                (>= (.indexOf ^String s ^String subs) 0) true
                :else false)
        :cljs (not= (.indexOf s subs) -1))))
@@ -36,8 +41,8 @@
   "Check if the string starts with prefix."
   [s prefix]
   #?(:clj (cond
-            (nil? s) false
-            (nil? prefix) false
+            (nil? s) (nil? prefix)
+            (empty? prefix) true
             :else (let [region (slice s 0 (count prefix))]
                     (= region prefix)))
      :cljs (when-not (nil? s)
@@ -47,8 +52,8 @@
   "Check if the string ends with suffix."
   [s suffix]
   #?(:clj (cond
-            (nil? s) false
-            (nil? suffix) false
+            (nil? s) (nil? suffix)
+            (empty? suffix) true
             :else (let [len (count s)
                         region (slice s (- len (count suffix)) len)]
                     (= region suffix)))
@@ -71,14 +76,6 @@
   [s]
   (when-not (nil? s)
     (.toUpperCase #?(:clj ^String s :cljs s))))
-
-(defn empty?
-  "Checks if a string is empty."
-  [^String s]
-  (cond
-    (nil? s) true
-    (= (count s) 0) true
-    :else false))
 
 (defn blank?
   "Checks if a string is empty or contains only whitespace."

--- a/test/cuerdas/core_tests.cljc
+++ b/test/cuerdas/core_tests.cljc
@@ -24,20 +24,24 @@
     (t/is (str/contains? "abc" "ab"))
     (t/is (str/contains? "abc" ""))
     (t/is (not (str/contains? "abc" "cba")))
-    (t/is (not (str/contains? "abc" nil)))
+    (t/is (str/contains? "abc" nil))
     (t/is (not (str/contains? nil nil))))
 
   (t/testing "startswith?"
     (t/is (str/startswith? "abc" "ab"))
     (t/is (not (str/startswith? "abc" "cab")))
     (t/is (not (str/startswith? nil "ab")))
-    (t/is (not (str/startswith? "abc" nil))))
+    (t/is (str/startswith? "abc" nil))
+    (t/is (str/startswith? "abc" ""))
+    (t/is (str/startswith? nil nil)))
 
   (t/testing "endswith?"
     (t/is (str/endswith? "abc" "bc"))
     (t/is (not (str/endswith? "abc" "bca")))
     (t/is (not (str/endswith? nil "bc")))
-    (t/is (not (str/endswith? "abc" nil))))
+    (t/is (str/endswith? "abc" nil))
+    (t/is (str/endswith? "abc" ""))
+    (t/is (str/endswith? nil nil)))
 
   (t/testing "trim"
     (t/is (= "a" (str/trim " a ")))


### PR DESCRIPTION
This is breaking change.

This behavior is consistent with existing similar methods in both Java and goog.string.
The logic is that zero length string is "contained" between any two chars.

nil in Clojure is a replacement for empty collection in many situations so nil should be treated as empty string also.

Case when containing string is null produces NullPointerException so returning false for (starts-with? nil nil) is probably OK but I think it should be true.