### PR TITLE
add parse-int support for jvm clojure

### DIFF
--- a/src/cuerdas/core.cljc
+++ b/src/cuerdas/core.cljc
@@ -525,14 +525,18 @@
        :else (Double/parseDouble s)))
    )
 
-#?(:cljs
-   (defn parse-int
-     "Return the number value in integer form."
-     [s]
-     (let [rx (regexp "^\\s*-?0x" "i")]
-       (if (.test rx s)
-         (js/parseInt s 16)
-         (js/parseInt s 10)))))
+(defn parse-int
+  "Return the number value in integer form."
+  [s]
+  #?(:cljs
+    (let [rx (regexp "^\\s*-?0x" "i")]
+      (if (.test rx s)
+        (js/parseInt s 16)
+        (js/parseInt s 10)))
+    :clj
+    (if (and (string? s) (re-matches #"-?\d+(\.\d+)?" s))
+      (.longValue (Double. s))
+      Double/NaN)))
 
 #?(:clj
    (defn parse-long

--- a/test/cuerdas/core_tests.cljc
+++ b/test/cuerdas/core_tests.cljc
@@ -215,10 +215,13 @@
        (t/is (= 1.4 (str/parse-double "1.4")))
        (t/is (= 1.0 (str/parse-double "1")))))
 
-  #?(:cljs
-     (t/testing "parse-int"
-       (t/is (nan? (str/parse-int nil)))
-       (t/is (= 1 (str/parse-int "1.4")))))
+ (t/testing "parse-int"
+   (t/is (nan? (str/parse-int nil)))
+   #?(:cljs
+      (t/is (= 1 (str/parse-int "1.4")))
+      :clj
+      (t/is (= (Integer. "1")
+               (str/parse-int "1.4")))))
 
   #?(:clj
      (t/testing "parse-long"


### PR DESCRIPTION
This adds a `:clj` branch for `parse-int` along with a test for it.