### PR TITLE
add `<<`, the unindenting function

### DIFF
--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -782,7 +782,7 @@ Returns true for 1/on/true/yes string values (case-insensitive), false otherwise
 
 === format
 
-Simple string formatting function. 
+Simple string formatting function.
 
 The string formating works in two main modes: indexed and associative.
 
@@ -963,6 +963,31 @@ Escape characters on the string that are not safe to use in a RegExp.
 ----
 (str/escape-regexp "\s")
 ;; => "\\s"
+----
+
+
+=== <<
+
+Unindent lines. Either strip preceeding whitespace automatically or
+with a user supplied regex.
+
+[source, clojure]
+----
+(str/<< "first line
+
+           second line (indented)
+
+         another line")
+----
+
+yields the string
+
+----
+first line
+
+  second line (indented)
+
+another line
 ----
 
 

--- a/src/cuerdas/core.cljc
+++ b/src/cuerdas/core.cljc
@@ -676,3 +676,17 @@
             second
             (split suffix)
             first)))
+
+(defn <<
+  "Unindent multiline text.
+  Uses either a supplied regex or the shortest
+  beginning-of-line to non-whitespace distance"
+  ([s]
+   (let [all-indents (->> (rest (lines s)) ;; ignore the first line
+                          (remove blank?)
+                          (concat [(last (lines s))]) ;; in case all lines are indented
+                          (map #(->> % (re-find #"^( +)") second count)))
+         min-indent  (re-pattern (format "^ {%s}"
+                                         (apply min all-indents)))]
+     (<< min-indent s)))
+  ([r s] (->> s lines (map #(replace % r "")) unlines)))

--- a/test/cuerdas/core_tests.cljc
+++ b/test/cuerdas/core_tests.cljc
@@ -329,6 +329,16 @@
     (t/is (= "foo" (str/substr-between "---foo>>bar--foo1>>bar" "---" ">>"))))
   )
 
+  (t/testing "<<"
+    (t/is (= "first line\n  indented two\n\n    indented four\n"
+             (str/<< "first line
+                        indented two
+
+                          indented four
+                      ")))
+    (t/is (= "first\nsecond\n  third"
+             (str/<< #"\t" "first\n\tsecond\n\t  third"))))
+
 #?(:cljs
    (do
      (enable-console-print!)


### PR DESCRIPTION
The function should match everything mentioned in #24, and there's a test for each arity :heavy_check_mark: 

Should anything special be added for the docs?