### PR TITLE
Keyword safety

### DIFF
--- a/doc/content-docinfo.html
+++ b/doc/content-docinfo.html
@@ -1,2 +1,4 @@
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic|Liberation+Mono:400|Roboto+Slab:400,700"/>
-<link rel="stylesheet" href="https://www.niwi.nz/_assets/asciidoctor-styles/simple-red-titles/stylesheet.css"/>
+<link rel="stylesheet"
+      href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic|Liberation+Mono:400|Roboto+Slab:400,700"/>
+<link rel="stylesheet"
+      href="https://www.niwi.nz/_assets/asciidoctor-styles/simple-red-titles/stylesheet.css"/>

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -209,7 +209,7 @@ Checks if a string contains only alphanumeric characters.
 
 === upper
 
-Converts string to all upper-case.
+Convert a string to all upper-case.
 
 [source, clojure]
 ----
@@ -223,7 +223,7 @@ Converts string to all upper-case.
 
 === lower
 
-Converts string to all lower-case.
+Convert a string to all lower-case.
 
 [source, clojure]
 ----
@@ -346,7 +346,7 @@ the string untouched.
 
 === collapse-whitespace
 
-Converts all adjacent whitespace characters to a single space.
+Converts any adjacent whitespace characters to a single space.
 
 [source, clojure]
 ----
@@ -606,20 +606,6 @@ Unquote a string.
 ----
 
 
-=== slugify
-
-Transforms string into URL slug.
-
-[source, clojure]
-----
-(str/slugify "Un éléphant à l'orée du bois")
-;; => "un-elephant-a-loree-du-bois"
-
-(str/slugify nil)
-;; => nil
-----
-
-
 === strip-tags
 
 Remove html tags from string.
@@ -857,9 +843,23 @@ By default, pads on the left with the space char.
 ----
 
 
+=== slug
+
+Transforms string or keyword into URL slug.
+
+[source, clojure]
+----
+(str/slug "Un éléphant à l'orée du bois")
+;; => "un-elephant-a-loree-du-bois"
+
+(str/slug nil)
+;; => nil
+----
+
+
 === capitalize
 
-Converts first letter of the string to uppercase.
+Uppercases the first character of a string.
 
 [source, clojure]
 ----
@@ -871,86 +871,178 @@ Converts first letter of the string to uppercase.
 ----
 
 
-=== camelize
+=== camel
 
-Converts a string from selector-case to camelCase.
+Convert a string or keyword to a camelCased string.
 
 [source, clojure]
 ----
-(str/camelize "foo bar")
+(str/camel "foo bar")
 ;; => "fooBar"
 
-(str/camelize nil)
+(str/camel :foo_barBaz)
+;; => "fooBarBaz"
+
+(str/camel nil)
 ;; => nil
 ----
 
 
-=== dasherize
+=== kebab
 
-Converts a underscored or camelized string into an dasherized one.
+Convert a string or keyword into a kebab-cased-string.
 
 [source, clojure]
 ----
-(str/dasherize "MozTransform")
-;; => "-moz-transform"
+(str/kebab "Favorite BBQ food")
+;; => "favorite-bbq-food"
 
-(str/dasherize nil)
+(str/kebab :favorite-bbq-food)
+;; => "favorite-bbq-food"
+
+(str/kebab nil)
 ;; => nil
 ----
 
 
-=== underscored
+=== snake
 
-Converts a camelized or dasherized string into an underscored one.
+Convert a string or keyword to a snake_cased_string.
 
 [source, clojure]
 ----
-(str/underscored "MozTransform")
-;; => "moz_transform"
+(str/snake "Slither-sliter Slither")
+;; => "slither_slither_slither"
 
-(str/underscored nil)
+(str/snake :slither-slither)
+;; => "slither_slither"
+
+(str/snake nil)
 ;; => nil
 ----
 
 
-=== titleize
+=== pascal
 
-Converts a string into TitleCase.
+Convert a string or keyword into a PascalCasedString
+(aka, UpperCamelCase and ClassCase).
 
 [source, clojure]
 ----
-(str/titleize "my name is epeli")
-;; => "My Name Is Epeli"
+(str/pascal "my name is epeli")
+;; => "MyNameIsEpeli"
 
-(str/titleize nil)
+(str/pascal :some-record)
+;; => "SomeRecord"
+
+(str/pascal nil)
 ;; => nil
 ----
 
 
-=== classify
+=== human
 
-Converts string to camelized class name. First letter is always upper case.
+Convert a string or keyword to a human friendly string
+(lower case and spaces).
 
 [source, clojure]
 ----
-(str/classify "some_class_name")
-;; => "SomeClassName"
+(str/human "JustNiceForReading")
+;; => "just nice for reading"
 
-(str/classify nil)
+(str/human :great-for-csv-headers
+;; => "great for csv headers"
+
+(str/human nil)
 ;; => nil
 ----
 
+=== title
 
-=== humanize
-
-Converts an underscored, camelized, or dasherized string into a humanized one.
+Convert a string or keyword into a space separated string
+with each word capitalized.
 
 [source, clojure]
 ----
-(str/humanize "  capitalize dash-CamelCase_underscore trim  ")
+(str/title "a tale of two cities")
+;; => "A Tale Of Two Cities"
+
+(str/title :title-case
+;; => "Title Case"
+
+(str/title nil)
+;; => nil
+----
+
+=== phrase
+
+Convert a potentially mixed string or keyword into a
+capitalized, spaced string
+
+[source, clojure]
+----
+(str/phrase "  capitalize dash-CamelCase_underscore trim  ")
 ;; => "Capitalize dash camel case underscore trim"
 
-(str/humanize nil)
+(str/phrase :nobody-uses-keywords-this-long-but-it-still-works
+;; => "Nobody uses keywords this long but it still works"
+
+(str/phrase nil)
+;; => nil
+----
+
+
+=== css-selector
+
+Convert a JavaScript style selector to CSS style selector
+
+[source, clojure]
+----
+(str/css-selector "PrependedWithDash")
+;; => "-prepended-with-dash"
+
+(str/css-selector "noPrependedWithDash")
+;; => "no-prepended-with-dash"
+
+(str/css-selector nil)
+;; => nil
+----
+
+
+=== js-selector
+
+Convert a CSS style selector to JavaScript style selector.
+
+[source, clojure]
+----
+(str/js-selector "-pascal-case-me")
+;; => "PascalCaseMe"
+
+(str/js-selector "camel-case-me")
+;; => "camelCaseMe"
+
+(str/js-selector nil)
+;; => nil
+----
+
+
+=== keyword
+
+A more helpful and forigiving version of `clojure.core/keyword`.
+
+[source, clojure]
+----
+(str/keyword "just_doIt Right")
+;; => :just-do-it-right
+
+(str/keyword "foo" "auto namespace me")
+;; => :foo/auto-namespace-me
+
+;; and assuming the user namespace
+(str/keyword *ns* "auto namespace me")
+;; => :user/auto-namespace-me
+
+(str/keyword nil)
 ;; => nil
 ----
 
@@ -1014,7 +1106,9 @@ $ node ./out/tests.js
 
 == How to Contribute?
 
-**cuerdas** unlike Clojure and other Clojure contrib libs, does not have many
+**cuerdas**' source is on https://github.com/funcool/cuerdas[github].
+
+Unlike Clojure and other Clojure contrib libs, cuerdas does not have many
 restrictions for contributions.
 
 *Pull requests are welcome!*

--- a/src/cuerdas/core.cljc
+++ b/src/cuerdas/core.cljc
@@ -1,5 +1,6 @@
 (ns cuerdas.core
-  (:refer-clojure :exclude [contains? empty? repeat replace reverse chars
+  (:refer-clojure :exclude [contains? empty? repeat
+                            replace reverse chars keyword
                             #?@(:clj [unquote format])])
   (:require [clojure.string :as str]
             #?(:cljs [goog.string :as gstr])
@@ -145,6 +146,13 @@
            rxstr (str "^" rxstr "+|" rxstr "+$")]
        (as-> (re-pattern rxstr) rx
          (replace s rx ""))))))
+
+(defn clean
+  "Trim and replace multiple spaces with
+  a single space."
+  [s]
+  (-> (trim s)
+      (replace #"\s+" " ")))
 
 (defn rtrim
   "Removes whitespace or specified characters
@@ -329,7 +337,7 @@
                        (if (= (subs match 0 1) "$")
                          (subs match 1)
                          (slice match 2 -2)))
-                  val (if (symbol? val) (keyword val) val)]
+                  val (if (symbol? val) (clojure.core/keyword val) val)]
               (str (get params val ""))))]
     (as-> #"(?:%\([\d\w\:\_\-]+\)s|\$[\w\d\:\_\-]+)" $
       (replace s $ on-match))))
@@ -390,100 +398,129 @@
   ([s qchar]
    (unsurround s qchar)))
 
-(defn dasherize
-  "Converts a underscored or camelized string
-  into an dasherized one."
+(defn- stylize-split
   [s]
   (some-> s
-          (trim)
-          (replace #"([A-Z]+)" "-$1")
-          (replace #"[-_\s]+" "-")
-          (strip-prefix "-")
-          (lower)))
+          (name)
+          (replace #"[A-Z]+[a-z]*" #(str "-" %))
+          (lower)
+          (split #"[^a-zA-Z]+")
+          (seq)))
 
-(defn slugify
+(defn- stylize-join
+  ([coll every-fn join-with] (stylize-join coll every-fn every-fn join-with))
+  ([[fst & rst] first-fn rest-fn join-with]
+    (when-not (nil? fst)
+      (join join-with
+            (into [(first-fn fst)] (map rest-fn rst))))))
+
+(defn stylize
+  ([s every-fn join-with] (stylize s every-fn every-fn join-with))
+  ([s first-fn rest-fn join-with]
+    (let [remove-empty #(seq (remove (partial = "") %))]
+      (some-> s
+              (stylize-split)
+              (remove-empty)
+              (stylize-join first-fn rest-fn join-with)))))
+
+(defn- update-range
+  [s [lower upper] update-fn]
+  (when (and (string? s) (not-empty s))
+    (let [length (count s)
+          start  (max 0 lower)
+          end    (min length upper)]
+      (str (subs s 0 start)
+           (update-fn (subs s start end))
+           (subs s end)))))
+
+(defn capitalize
+  "Uppercases the first character of a string or keyword"
+  [s]
+  (when s
+    (update-range (name s) [0 1] upper)))
+
+(defn camel
+  "Output will be: lowerUpperUpperNoSpaces
+  accepts strings and keywords"
+  [s]
+  (stylize s lower capitalize ""))
+
+(defn snake
+  "Output will be: lower_cased_and_underscore_separated
+  accepts strings and keywords"
+  [s]
+  (stylize s lower "_"))
+
+(defn phrase
+  "Output will be: Space separated with the first letter capitalized.
+  accepts strings and keywords"
+  [s]
+  (stylize s capitalize lower " "))
+
+(defn human
+  "Output will be: lower cased and space separated
+  accepts strings and keywords"
+  [s]
+  (stylize s lower " "))
+
+(defn title
+  "Output will be: Each Word Capitalized And Separated With Spaces
+  accepts strings and keywords"
+  [s]
+  (stylize s capitalize " "))
+
+(defn pascal
+  "Output will be: CapitalizedAndTouchingTheNext
+  accepts strings and keywords"
+  [s]
+  (stylize s capitalize ""))
+
+(defn kebab
+  "Output will be: lower-cased-and-separated-with-dashes
+  accepts strings and keywords"
+  [s]
+  (stylize s lower "-"))
+
+(defn js-selector
+  "Output will be either:
+     (js-selector \"-pascal-case-me\") ;; => PascalCaseMe
+     (js-selector \"camel-case-me\") ;; => camelCaseMe
+
+  accepts keywords and strings, with any standard delimiter"
+  [s]
+  (some-> s
+          (stylize-split)
+          (stylize-join capitalize "")))
+
+(defn css-selector
+  "Output will be either:
+     (js-selector \"LeadingDash\") ;; => -leading-dash
+     (js-selector \"noLeadingDash\") ;; => no-leading-dash
+
+  accepts keywords and strings, with any standard delimiter"
+  [s]
+  (some-> s
+          (stylize-split)
+          (stylize-join lower "-")))
+
+(defn slug
   "Transform text into a URL slug."
   [s]
   (when s
-    (let [from  "ąàáäâãåæăćčĉęèéëêĝĥìíïîĵłľńňòóöőôõðøśșšŝťțŭùúüűûñÿýçżźž"
-          to    "aaaaaaaaaccceeeeeghiiiijllnnoooooooossssttuuuuuunyyczzz"
-          regex (re-pattern (str "[" (escape-regexp from) "]"))]
-      (-> (lower s)
-          (replace regex (fn [^String c]
-                           (let [index (.indexOf from c)
-                                 res   #?(:clj  (String/valueOf (.charAt to index))
-                                          :cljs (.charAt to index))]
-                             (if (empty? res) "-" res))))
-          (replace #"[^\w\s-]" "")
-          (dasherize)))))
+    (-> (lower s)
+        (name)
+        (str/escape (zipmap "ąàáäâãåæăćčĉęèéëêĝĥìíïîĵłľńňòóöőôõðøśșšŝťțŭùúüűûñÿýçżźž"
+                            "aaaaaaaaaccceeeeeghiiiijllnnoooooooossssttuuuuuunyyczzz"))
+        (replace #"[^\w\s]+" "")
+        (kebab))))
 
-(defn capitalize
-  "Converts first letter of the string to uppercase."
-  [s]
-  (when-not (nil? s)
-    (-> (.charAt ^String s 0)
-        #?(:clj (String/valueOf))
-        (upper)
-        (str (slice s 1)))))
-
-(defn camelize
-  "Converts a string from selector-case to camelCase."
-  [s]
-  (some-> s
-          (trim)
-          (replace #?(:clj  #"[-_\s]+(.)?"
-                      :cljs (regexp #"[-_\s]+(.)?" "g"))
-                   (fn [[match c]] (if c (upper c) "")))))
-
-(defn underscored
-  "Converts a camelized or dasherized string
-  into an underscored one."
-  [s]
-  (some-> s
-          (trim)
-          (replace #?(:clj  #"([a-z\d])([A-Z]+)"
-                      :cljs (regexp #"([a-z\d])([A-Z]+)" "g"))"$1_$2")
-          (replace #?(:clj  #"[-\s]+"
-                      :cljs (regexp #"[-\s]+", "g")) "_")
-          (lower)))
-
-(defn humanize
-  "Converts an underscored, camelized, or
-  dasherized string into a humanized one."
-  [s]
-  (some-> s
-          (underscored)
-          (replace #"_id$", "")
-          (replace #?(:clj "_" :cljs (regexp "_" "g")) " ")
-          (capitalize)))
-
-(defn titleize
-  "Converts a string into TitleCase."
-  ([s]
-   #?(:clj  (titleize s nil)
-      :cljs (when-not (nil? s)
-              (gstr/toTitleCase s))))
-  ([s delimeters]
-   #?(:clj
-      (when-not (nil? s)
-        (let [delimeters (if delimeters
-                           (escape-regexp delimeters)
-                           "\\s")
-              delimeters (str "|[" delimeters "]+")
-              rx         (re-pattern (str "(^" delimeters ")([a-z])"))]
-          (replace s rx (fn [[c1 _]]
-                          (upper c1)))))
-      :cljs (gstr/toTitleCase s delimeters))))
-
-(defn classify
-  "Converts string to camelized class name. First letter is always upper case."
-  [s]
-  (some-> s
-          (str)
-          (replace #"[\W_]" " ")
-          (camelize)
-          (replace #"\s" "")
-          (capitalize)))
+(defn keyword
+  "Safer version of clojure.core/keyword, accepting a
+  symbol for the namespace and kebab-casing the key"
+  ([k]
+    (clojure.core/keyword (kebab k)))
+  ([n k]
+    (clojure.core/keyword (str n) (kebab k))))
 
 #?(:cljs
    (defn- parse-number-impl
@@ -653,13 +690,6 @@
      (strip-tags-impl s tags {}  )))
   ([s tags mapping]
    (strip-tags-impl s tags mapping)))
-
-(defn clean
-  "Trim and replace multiple spaces with
-  a single space."
-  [s]
-  (-> (trim s)
-      (replace #"\s+" " ")))
 
 (defn substr-between
   "Find string that is nested in between two strings. Return first match"

--- a/test/cuerdas/core_tests.cljc
+++ b/test/cuerdas/core_tests.cljc
@@ -164,10 +164,10 @@
     (t/is (= "\"" (str/unquote "\"\"\"")))
     (t/is (= "a" (str/unquote "\"a\""))))
 
-  (t/testing "slugify"
-    (t/is (= nil (str/slugify nil)))
+  (t/testing "slug"
+    (t/is (= nil (str/slug nil)))
     (t/is (= "un-elephant-a-loree-du-bois"
-             (str/slugify "Un éléphant à l'orée du bois"))))
+             (str/slug "Un éléphant à l'orée du bois"))))
 
   (t/testing "clean"
     (t/is (= nil (str/clean nil)))
@@ -270,38 +270,67 @@
     (t/is (= "a" (str/strip-suffix "a=-" "=-")))
     (t/is (= "a-=" (str/strip-suffix "a-=" "=-"))))
 
-  (t/testing "camelize"
-    (t/is (= nil (str/camelize nil)))
-    (t/is (= "MozTransform" (str/camelize "-moz-transform")))
-    (t/is (= "mozTransform" (str/camelize "moz-transform")))
-    (t/is (= "mozTransform" (str/camelize "moz transform"))))
-
   #?(:clj
      (t/testing "strip-suffix"
        (t/is (= nil (str/strip-suffix nil "foo")))
        (t/is (= "foobar" (str/strip-suffix "foobar-" "-")))))
 
-  (t/testing "dasherize"
-    (t/is (= nil (str/dasherize nil)))
-    (t/is (= "moz" (str/dasherize "MOZ")))
-    (t/is (= "moz-transform" (str/dasherize "MozTransform"))))
+  (t/testing "camel"
+    (t/is (= nil (str/camel nil)))
+    (t/is (= "mozTransform" (str/camel :-moz-transform)))
+    (t/is (= "mozTransform" (str/camel :moz-transform)))
+    (t/is (= "mozTransform" (str/camel "moz_transform")))
+    (t/is (= "mozTransform" (str/camel "moz transform"))))
 
-  (t/testing "underscored"
-    (t/is (= nil (str/underscored nil)))
-    (t/is (= "moz_transform" (str/underscored "MozTransform"))))
+  (t/testing "kebab"
+   (t/is (= nil (str/kebab nil)))
+   (t/is (= "moz" (str/kebab "MOZ")))
+   (t/is (= "dasherized-keyword" (str/kebab :dasherized-keyword)))
+   (t/is (= "moz-transform" (str/kebab "MozTransform"))))
 
-  (t/testing "humanize"
-    (t/is (= nil (str/humanize nil)))
+
+  (t/testing "snake"
+    (t/is (= nil (str/snake nil)))
+    (t/is (= "user_table" (str/snake :user-table)))
+    (t/is (= "moz_transform" (str/snake "MozTransform"))))
+
+  (t/testing "phrase"
+    (t/is (= nil (str/phrase nil)))
+    (t/is (= "A short phrase" (str/phrase :a-short-phrase)))
     (t/is (= "Capitalize dash camel case underscore trim"
-             (str/humanize "  capitalize dash-CamelCase_underscore trim  "))))
+             (str/phrase "  capitalize dash-CamelCase_underscore trim  "))))
 
-  (t/testing "titleize"
-    (t/is (= nil (str/titleize nil)))
-    (t/is (= "My Name Is Epeli" (str/titleize "my name is epeli"))))
+  (t/testing "human"
+    (t/is (= nil (str/human nil)))
+    (t/is (= "human friendly" (str/human :human-friendly)))
+    (t/is (= "nice for people to read" (str/human "NiceForPeopleToRead"))))
 
-  (t/testing "classify"
-    (t/is (= nil (str/classify nil)))
-    (t/is (= "SomeClassName" (str/classify "some_class_name"))))
+  (t/testing "title"
+    (t/is (= nil (str/title nil)))
+    (t/is (= "My Name Is Epeli" (str/title "my name is epeli")))
+    (t/is (= "Regular Keyword" (str/title :regular-keyword))))
+
+  (t/testing "pascal"
+    (t/is (= nil (str/pascal nil)))
+    (t/is (= "SomeKeywordName" (str/pascal :*some-keyword-name*)))
+    (t/is (= "SomeClassName" (str/pascal "_some_class_name_"))))
+
+  (t/testing "js-selector"
+    (t/is (= nil (str/js-selector nil)))
+    (t/is (= "SomeKeywordName" (str/js-selector :-some-keyword-name)))
+    (t/is (= "SomeClassName" (str/js-selector "_some_class_name"))))
+
+  (t/testing "css-selector"
+    (t/is (= nil (str/css-selector nil)))
+    (t/is (= "-some-keyword-name" (str/css-selector :SomeKeywordName)))
+    (t/is (= "-some-keyword-name" (str/css-selector "SomeKeywordName"))))
+
+  (t/testing "keyword"
+    (t/is (= nil (str/css-selector nil)))
+    (t/is (= :keyword-this (str/keyword " keyword this")))
+    (t/is (= :bar-foo/key-this (str/keyword "bar-foo" " Key_This")))
+    (let [n "foo-bar"]
+      (t/is (= :foo-bar/key-that (str/keyword n "KeyThat")))))
 
   (t/testing "lines"
     (t/is (= nil (str/lines nil)))


### PR DESCRIPTION
Follow up on #32 

This is a larger step than I mentioned in the issue, but it should (hopefully) be for the best: instead of using names like `dasherize`, `underscore`, and `classify` appropriate non-verbs were swapped in. It's a bit like what clojure does with `keyword`, `vector`, and `hash-map` being named after what they return instead of how they do it.  

All the new functions sit on top of a new `stylize` function to keep behaviour consistent: 

  * `camel` - always a lower case first letter, capitalized after that
  * `snake` - all lower case, with `_` delimiting
  * `phrase` - like the old humanize, a capital first letter
  * `human` - just spaces and lower case
  * `title` - capitalized words and spaces
  * `pascal` - old `classify`, this seems to be the standard term
  * `kebab` - old `dasherize`, kebab-case looks like the usual term 

The next two are for `-moz-transition` <-> `MozTransition` and  `transition` <-> `transition`. Hopefully pulling them out makes things more predictable.

  * `js-selector` - can yield either pascal or camel case depending on the input
  * `css-selector` - dasherized with a potential `-` a the start

And finally, since all the new versions are keyword-safe, there's the new cuerdas function for the reverse:

  * `keyword` - safer version of the clojure version, dasherizes the arg

These new functions all have tests, but I haven't updated the docs yet (plus it's getting late here, so there are likely a few other errors). 

In the current state, this PR is just for comments/opinions.
 