### PR TITLE
Trim should trim all whitespace characters

### DIFF
--- a/src/cuerdas/core.cljc
+++ b/src/cuerdas/core.cljc
@@ -138,7 +138,7 @@
 (defn trim
   "Removes whitespace or specified characters
   from both ends of string."
-  ([s] (trim s " "))
+  ([s] (trim s "\\s"))
   ([s chs]
    (when-not (nil? s)
      (let [rxstr (str "[" #?(:clj chs :cljs (escape-regexp chs)) "]")
@@ -149,7 +149,7 @@
 (defn rtrim
   "Removes whitespace or specified characters
   from right side of string."
-  ([s] (rtrim s " "))
+  ([s] (rtrim s "\\s"))
   ([s chs]
    (when-not (nil? s)
      (let [rxstr (str "[" #?(:clj chs :cljs (escape-regexp chs)) "]")
@@ -160,7 +160,7 @@
 (defn ltrim
   "Removes whitespace or specified characters
   from left side of string."
-  ([s] (ltrim s " "))
+  ([s] (ltrim s "\\s"))
   ([s chs]
    (when-not (nil? s)
      (let [rxstr (str "[" #?(:clj chs :cljs (escape-regexp chs)) "]")


### PR DESCRIPTION
The `trim`/`ltrim`/`rtrim` functions say in their docstrings that they trim whitespace. However, they were by default only trimming space characters. I've replaced the space with the regex whitespace metacharacter, so they should behave like `clojure.string/trim`/`triml`/`trimr`