### PR TITLE
Resolve warnings by replacing NaN with js/NaN

### DIFF
--- a/src/cuerdas/core.cljc
+++ b/src/cuerdas/core.cljc
@@ -640,10 +640,10 @@
   and floats."
   [s]
   (if (nil? s)
-    #?(:cljs NaN :clj Double/NaN)
+    #?(:cljs js/NaN :clj Double/NaN)
     (if (numeric? s)
       (edn/read-string s)
-      #?(:cljs NaN :clj Double/NaN))))
+      #?(:cljs js/NaN :clj Double/NaN))))
 
 (defn parse-double
   "Return the double value from string."


### PR DESCRIPTION

See https://github.com/funcool/cuerdas/issues/58

WARNING: Use of undeclared Var cuerdas.core/NaN at line 643 resources\public\js\dev\cuerdas\core.cljc
WARNING: Use of undeclared Var cuerdas.core/NaN at line 646 resources\public\js\dev\cuerdas\core.cljc