### PR TITLE
Fix #62 - problems during Advanced Compilation

### DIFF
--- a/src/cuerdas/core.cljc
+++ b/src/cuerdas/core.cljc
@@ -193,7 +193,7 @@
   [^String s]
   (when (string? s)
     (or (zero? (count s))
-        (boolean (-> (rx/enhace #"^[\s\p{Z}]+$")
+        (boolean (-> (rx/enhace (re-pattern "^[\\s\\p{Z}]+$"))
                      (re-matches s))))))
 
 (defn alpha?
@@ -219,14 +219,14 @@
   This function will use all the unicode range."
   [s]
   (when (string? s)
-    (boolean (re-matches (rx/enhace #"^[\p{N}\p{L}_-]+$") s))))
+    (boolean (re-matches (rx/enhace (re-pattern "^[\\p{N}\\p{L}_-]+$")) s))))
 
 (defn letters?
   "Checks if string contains only letters.
   This function will use all the unicode range."
   [s]
   (when (string? s)
-    (boolean (re-matches (rx/enhace #"^\p{L}+$") s))))
+    (boolean (re-matches (rx/enhace (re-pattern "^\\p{L}+$")) s))))
 
 (defn numeric?
   "Check if a string contains only numeric values."
@@ -274,7 +274,7 @@
   a single space."
   [s]
   (-> (trim s)
-      (replace (rx/enhace #"[\s\p{Z}]+") " ")))
+      (replace (rx/enhace (re-pattern "[\\s\\p{Z}]+")) " ")))
 
 (def strip trim)
 (def rstrip rtrim)
@@ -427,7 +427,7 @@
 (defn words
   "Returns a vector of the words in the string."
   ([s]
-   (words s (rx/enhace #"[\p{N}\p{L}_-]+")))
+   (words s (rx/enhace (re-pattern "[\\p{N}\\p{L}_-]+"))))
   ([s re]
    (when (string? s)
      (vec (re-seq re s)))))
@@ -514,8 +514,8 @@
 
 (defn- stylize-split
   [s]
-  (let [re1 (rx/enhace #"(\p{Lu}+[\p{Ll}\u0027\p{Ps}\p{Pe}]*)")
-        re2 (rx/enhace #"[^\p{L}\p{N}\u0027\p{Ps}\p{Pe}]+")]
+  (let [re1 (rx/enhace (re-pattern "(\\p{Lu}+[\\p{Ll}\\u0027\\p{Ps}\\p{Pe}]*)"))
+        re2 (rx/enhace (re-pattern "[^\\p{L}\\p{N}\\u0027\\p{Ps}\\p{Pe}]+"))]
     (some-> s
             (name)
             (replace re1 "-$1")
@@ -623,8 +623,8 @@
   "Unicode friendly version of `slug` function."
   [s]
   (some-> (lower s)
-          (replace (rx/enhace #"[^\p{L}\p{N}]+") " ")
-          (replace (rx/enhace #"[\p{Z}\s]+") "-")))
+          (replace (rx/enhace (re-pattern "[^\\p{L}\\p{N}]+")) " ")
+          (replace (rx/enhace (re-pattern "[\\p{Z}\\s]+")) "-")))
 
 (defn keyword
   "Safer version of clojure keyword, accepting a
@@ -695,7 +695,7 @@
   to a single space."
   [s]
   (some-> s
-          (replace (rx/enhace #"[\p{Z}\s]+") " ")
+          (replace (rx/enhace (re-pattern "[\\p{Z}\\s]+")) " ")
           (replace #"^\s+|\s+$" "")))
 
 (defn escape-html


### PR DESCRIPTION
It seems that Google Closure advanced compiler does not like \p regex tags in regex literals (#"\p" gets converted into #"p").

I only tested under shadow-cljs, so I'm not sure if this is a general issue.

This patch changes the offending regex literals to use re-pattern.