### PR TITLE
change clj long parsing logic

### DIFF
--- a/src/cuerdas/core.cljc
+++ b/src/cuerdas/core.cljc
@@ -672,7 +672,7 @@
 
     (and (string? s)
          (re-matches #"-?\d+(\.\d+)?" s))
-    #?(:clj (.longValue (Double. ^String s))
+    #?(:clj (.longValue (java.math.BigDecimal. ^String s))
        :cljs (js/parseInt s 10))
 
     :else


### PR DESCRIPTION
do not coerce a long string into double which causes a loss of
precision