### PR TITLE
Fix tests doc & replace-with warning

### DIFF
--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -1322,19 +1322,14 @@ expression that matches a single word (defaults to `[a-zA-Z0-9_-]+`).
 _cuerdas_ has targeted some parts of implementation for Clojure and
 ClojureScript using Reader Conditionals.
 
-.Run tests in the Clojure environment using Leiningen.
+.Run tests in the Clojure environment.
 ----
-$ lein test cuerdas.core-tests
-----
-
-.Compile ClojureScript to JavaScript.
-----
-$ ./scripts/build
+$ clj -A:dev ./tools.clj test
 ----
 
-.Run tests on compiled ClojureScript using node.
+.Run tests in the ClojureScript environment.
 ----
-$ node ./out/tests.js
+$ clj -A:dev ./tools.clj test-cljs
 ----
 
 

--- a/src/cuerdas/core.cljc
+++ b/src/cuerdas/core.cljc
@@ -324,7 +324,7 @@
        (rx/regexp? match)
        (if (string? replacement)
          (replace-all s match replacement)
-         (replace-all s match (str/replace-with replacement))))))
+         (replace-all s match (#'str/replace-with replacement))))))
 
 (defn replace
   "Replaces all instance of match with replacement in s.


### PR DESCRIPTION
The tests doc is outdated; I think I found the commands (tell me if those aren’t correct) and fixed the doc (fixes #75).

Also, there is a warning in cljs because [`str/replace-with`](https://github.com/clojure/clojurescript/blob/9a8196ebfe4265feda88a06de84affb9df469012/src/main/cljs/clojure/string.cljs#L36) is private. You can reproduce it on the latest master:

```
$ rm -rf out ; clj -A:dev ./tools.clj test-cljs 2>&1 | grep WARNING
WARNING: var: clojure.string/replace-with is not public at line 327 src/cuerdas/core.cljc
```

I fixed it as well (fixes #69).