### PR TITLE
link to cljdoc in readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -21,7 +21,7 @@ ____
 
 == Documentation
 
-http://funcool.github.io/cuerdas/latest/
+https://cljdoc.org/d/funcool/cuerdas
 
 
 == License


### PR DESCRIPTION
I'd suggest to also use this link for the website instead of using a link that points to a specific version. 