### PR TITLE
Fix starts-with / ends-with

### DIFF
--- a/src/cuerdas/core.cljc
+++ b/src/cuerdas/core.cljc
@@ -89,7 +89,7 @@
   (and (string? s)
        (or (string? prefix)
            (char? prefix))
-       (or (zero? (count s))
+       (or (zero? (count prefix))
            #?(:clj (let [region (slice s 0 (count prefix))]
                      (= region prefix))
               :cljs (= (.lastIndexOf s prefix 0) 0)))))
@@ -100,7 +100,7 @@
   (and (string? s)
        (or (string? suffix)
            (char? suffix))
-       (or (zero? (count s))
+       (or (zero? (count suffix))
            #?(:clj (let [len (count s)
                          region (slice s (- len (count suffix)) len)]
                      (= region suffix))

--- a/test/cuerdas/core_test.cljc
+++ b/test/cuerdas/core_test.cljc
@@ -47,19 +47,23 @@
     (t/is (= false (str/includes? "abc" nil))))
 
   (t/testing "starts-with?"
-    (t/is (= false (str/starts-with? nil "ab")))
     (t/is (= false (str/starts-with? nil nil)))
+    (t/is (= false (str/starts-with? nil "ab")))
+    (t/is (= false (str/starts-with? "" "ab")))
+    (t/is (= true (str/starts-with? "" "")))
+    (t/is (= false (str/starts-with? "abc" nil)))
     (t/is (= true (str/starts-with? "abc" "ab")))
     (t/is (= false (str/starts-with? "abc" "cab")))
-    (t/is (= false (str/starts-with? "abc" nil)))
     (t/is (= true (str/starts-with? "abc" ""))))
 
   (t/testing "ends-with?"
     (t/is (= false (str/ends-with? nil nil)))
     (t/is (= false (str/ends-with? nil "bc")))
+    (t/is (= false (str/ends-with? "" "bc")))
+    (t/is (= true (str/ends-with? "" "")))
     (t/is (= false (str/ends-with? "abc" nil)))
-    (t/is (= false (str/ends-with? "abc" "bca")))
     (t/is (= true (str/ends-with? "abc" "bc")))
+    (t/is (= false (str/ends-with? "abc" "bca")))
     (t/is (= true (str/ends-with? "abc" ""))))
 
   (t/testing "trim"


### PR DESCRIPTION
(starts-with? "" "ab") / (ends-with? "" "ab") returned true which didn't make sense. Probably a regression bug from the rewrite in #4ff5b32.