### PR TITLE
Fix trim functions understanding "E" and "Q" as whitespace

### DIFF
--- a/src/cuerdas/core.cljc
+++ b/src/cuerdas/core.cljc
@@ -313,13 +313,13 @@
     (re-pattern rxstr)))
 
 (def ^:private trim-default-re
-  (-> "\n\f\r\t " rx/escape str->trim-re))
+  (str->trim-re "\n\f\r\t "))
 
 (def ^:private rtrim-default-re
-  (-> "\n\f\r\t " rx/escape str->rtrim-re))
+  (str->rtrim-re "\n\f\r\t "))
 
 (def ^:private ltrim-default-re
-  (-> "\n\f\r\t " rx/escape str->ltrim-re))
+  (str->ltrim-re "\n\f\r\t "))
 
 (defn trim
   "Removes whitespace or specified characters

--- a/test/cuerdas/core_test.cljc
+++ b/test/cuerdas/core_test.cljc
@@ -82,6 +82,29 @@
   (t/is (= nil (str/rtrim nil)))
   (t/is (= "-a" (str/rtrim "-a-", "-"))))
 
+;; Check correct handling of java.util.regex.Pattern.quote, that adds \Q and \E
+;; sequences to quote strings, and it has been source of a bug that causes Q
+;; and E characters to be recognized as whitespace.
+;;   https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html
+;;   https://github.com/funcool/cuerdas/pull/94
+(t/deftest trim-fn-ghost-EQ
+  (t/is (= "EEstringEE" (str/trim "EEstringEE")))
+  (t/is (= "EEstringEE" (str/trim "  EEstringEE  ")))
+  (t/is (= "QQstringQQ" (str/trim "QQstringQQ")))
+  (t/is (= "QQstringQQ" (str/trim "  QQstringQQ  "))))
+
+(t/deftest ltrim-fn-ghost-EQ
+  (t/is (= "EEstringEE" (str/ltrim "EEstringEE")))
+  (t/is (= "EEstringEE  " (str/ltrim "  EEstringEE  ")))
+  (t/is (= "QQstringQQ" (str/ltrim "QQstringQQ")))
+  (t/is (= "QQstringQQ  " (str/ltrim "  QQstringQQ  "))))
+
+(t/deftest rtrim-fn-ghost-EQ
+  (t/is (= "EEstringEE" (str/rtrim "EEstringEE")))
+  (t/is (= "  EEstringEE" (str/rtrim "  EEstringEE  ")))
+  (t/is (= "QQstringQQ" (str/rtrim "QQstringQQ")))
+  (t/is (= "  QQstringQQ" (str/rtrim "  QQstringQQ  "))))
+
 (t/deftest empty-pred
   (t/is (str/empty? ""))
   (t/is (str/empty? nil))


### PR DESCRIPTION
## Summary

The `trim` functions understand upper case "E" and "Q" as whitespace. Example:
```clojure
(str/trim "Error")
> "rror"
(str/trim "Quit")
> "uit"
```

## Explanation

Clojure version of trim use `java.util.regex.Pattern.quote()` function to escape the `"\n\f\r\t "` expression used to match whitespaces. But this function does not generate `"\\n\\f\\r\\t "`, as in other languages, but `"\Q\n\f\r\t \E"`, being `\Q` a special character that means "quote everything until you find `\E`".

The bug was that the quote function was called twice, leading to `"\Q\Q\n\f\r\t \E\E"`. So one `\Q` and one `\E` ended up being part of the escaped regexp, and matched an uppercase Q or E as well as any whitespace.